### PR TITLE
Remove html_get_page success delay

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -116,7 +116,6 @@ def html_get_page(url: str, retry: int = MAX_RETRY, use_bypasser: bool = False) 
             rate_limit_attempts = 0
             response.raise_for_status()
             logger.debug(f"Success getting: {url}")
-            time.sleep(1)
             return str(response.text)
 
         except Exception as e:

--- a/testing/test_rate_limit.py
+++ b/testing/test_rate_limit.py
@@ -64,7 +64,7 @@ def test_html_get_page_respects_retry_after_seconds(monkeypatch, sleep_calls):
 
     assert result == "ok"
     assert pytest.approx(retry_after_seconds) == sleep_calls[0]
-    assert 1 in sleep_calls  # success sleep
+    assert len(sleep_calls) == 1
 
 
 def test_html_get_page_retry_after_http_date(monkeypatch, sleep_calls):
@@ -84,6 +84,21 @@ def test_html_get_page_retry_after_http_date(monkeypatch, sleep_calls):
 
     assert result == "ok"
     assert pytest.approx(retry_delay.total_seconds(), abs=1.0) == sleep_calls[0]
+    assert len(sleep_calls) == 1
+
+
+def test_html_get_page_success_does_not_sleep(monkeypatch, sleep_calls):
+    responses = [DummyResponse(200, text="ok")]
+
+    def fake_get(url, **kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr(downloader.requests, "get", fake_get)
+
+    result = downloader.html_get_page("http://example.com")
+
+    assert result == "ok"
+    assert sleep_calls == []
 
 
 def _install_dummy_tqdm(monkeypatch):


### PR DESCRIPTION
## Summary
- remove the fixed one-second sleep from `html_get_page` so successful fetches return immediately
- extend the rate-limit unit tests to assert only the intended backoff sleeps occur
- add a new test covering immediate success to ensure no artificial delay is introduced

## Testing
- pytest testing/test_rate_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68cf6c3eba60832d99c4e06baf09349f