### PR TITLE
Refine concurrent download loop scheduling

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,5 +1,14 @@
+import os
 import sys
 from pathlib import Path
+
+# Disable the background download coordinator during tests to keep the
+# environment deterministic.
+os.environ.setdefault("DISABLE_DOWNLOAD_COORDINATOR", "true")
+os.environ.setdefault("USE_CF_BYPASS", "false")
+os.environ.setdefault("AA_BASE_URL", "https://example.com")
+os.environ.setdefault("HTTP_PROXY", "")
+os.environ.setdefault("HTTPS_PROXY", "")
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 if str(ROOT_DIR) not in sys.path:


### PR DESCRIPTION
## Summary
- replace the busy-waiting logic in `concurrent_download_loop` with a wait-based scheduler that immediately reacts to free capacity and honours optional shutdown signalling
- enhance `BookQueue` with queue-availability signalling and blocking retrieval to support the new coordinator flow
- add pytest coverage for prompt scheduling and future error handling while configuring the test harness to disable the background coordinator during tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf6c3f48a4832d8380fae8dfd46b30