### PR TITLE
Handle missing local downloads gracefully

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -101,13 +101,14 @@ def queue_status() -> Dict[str, Dict[str, Any]]:
 
 def get_book_data(book_id: str) -> Tuple[Optional[bytes], BookInfo]:
     """Get book data for a specific book, including its title.
-    
+
     Args:
         book_id: Book identifier
-        
+
     Returns:
         Tuple[Optional[bytes], str]: Book data if available, and the book title
     """
+    book_info: Optional[BookInfo] = None
     try:
         book_info = book_queue._book_data[book_id]
         path = book_info.download_path
@@ -115,9 +116,10 @@ def get_book_data(book_id: str) -> Tuple[Optional[bytes], BookInfo]:
             return f.read(), book_info
     except Exception as e:
         logger.error_trace(f"Error getting book data: {e}")
-        if book_info:
+        if book_info is not None:
             book_info.download_path = None
-        return None, book_info if book_info else BookInfo(id=book_id, title="Unknown")
+            return None, book_info
+        return None, BookInfo(id=book_id, title="Unknown")
 
 def _book_info_to_dict(book: BookInfo) -> Dict[str, Any]:
     """Convert BookInfo object to dictionary representation."""

--- a/testing/test_local_download.py
+++ b/testing/test_local_download.py
@@ -1,0 +1,24 @@
+import pytest
+
+import app as flask_app
+import backend
+import models
+
+
+@pytest.fixture
+def client(monkeypatch):
+    queue = models.BookQueue()
+    monkeypatch.setattr(models, "book_queue", queue)
+    monkeypatch.setattr(backend, "book_queue", queue)
+
+    flask_app.app.config.update(TESTING=True)
+    with flask_app.app.test_client() as client:
+        yield client
+
+
+def test_localdownload_missing_id_returns_404(client):
+    response = client.get("/api/localdownload", query_string={"id": "missing"})
+
+    assert response.status_code == 404
+    assert response.is_json
+    assert response.get_json() == {"error": "File not found"}


### PR DESCRIPTION
## Summary
- initialize book lookups defensively so backend.get_book_data always returns a BookInfo fallback
- only clear download paths for books that were retrieved and fall back to an "Unknown" title when lookup fails
- add a Flask integration test that verifies /api/localdownload returns a 404 for unknown IDs

## Testing
- pytest testing/test_local_download.py


------
https://chatgpt.com/codex/tasks/task_e_68cf7d5065b4832daab9d63f5e73730f