### PR TITLE
Handle stale queue entries cleared concurrently

### DIFF
--- a/models.py
+++ b/models.py
@@ -103,6 +103,12 @@ class BookQueue:
             book_id = queue_item.book_id
 
             with self._lock:
+                # Skip items that were cleared while waiting for the lock
+                if book_id not in self._book_data or book_id not in self._status:
+                    if self._queue.empty():
+                        self._queue_not_empty.clear()
+                    continue
+
                 # Check if book was cancelled while in queue
                 if (
                     book_id in self._status


### PR DESCRIPTION
## Summary
- skip queue items whose metadata was removed while get_next waited for the lock
- keep cancellation handling unchanged but clear the queue-not-empty flag when skipping stale entries
- add a regression test covering concurrent clear_completed and get_next so downloads are not started for cleared jobs

## Testing
- pytest testing/test_concurrent_loop.py

------
https://chatgpt.com/codex/tasks/task_e_68cfac1a7ffc832d81ab68fe77974f68