### PR TITLE
Fix custom logger trace helpers and add test

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -13,22 +13,26 @@ class CustomLogger(logging.Logger):
     def error_trace(self, msg: Any, *args: Any, **kwargs: Any) -> None:
         """Log an error message with full stack trace."""
         self.log_resource_usage()
-        self.error(msg, *args, exc_info=True, **kwargs)
+        kwargs.setdefault("exc_info", True)
+        self.error(msg, *args, **kwargs)
 
     def warning_trace(self, msg: Any, *args: Any, **kwargs: Any) -> None:
         """Log a warning message with full stack trace."""
         self.log_resource_usage()
-        self.warning(msg, *args, exc_info=True, **kwargs)
-    
+        kwargs.setdefault("exc_info", True)
+        self.warning(msg, *args, **kwargs)
+
     def info_trace(self, msg: Any, *args: Any, **kwargs: Any) -> None:
         """Log an info message with full stack trace."""
         self.log_resource_usage()
-        self.info(msg, *args, exc_info=True, **kwargs)
-    
+        kwargs.setdefault("exc_info", True)
+        self.info(msg, *args, **kwargs)
+
     def debug_trace(self, msg: Any, *args: Any, **kwargs: Any) -> None:
         """Log a debug message with full stack trace."""
         self.log_resource_usage()
-        self.debug(msg, *args, exc_info=True, **kwargs)
+        kwargs.setdefault("exc_info", True)
+        self.debug(msg, *args, **kwargs)
     
     def log_resource_usage(self):
         import psutil

--- a/testing/test_logger.py
+++ b/testing/test_logger.py
@@ -1,0 +1,28 @@
+import logging
+
+from logger import CustomLogger
+
+
+def test_error_trace_respects_explicit_exc_info(monkeypatch):
+    """Calling error_trace with exc_info=True should not raise and reaches Logger.error."""
+
+    logger = CustomLogger("test-logger")
+
+    calls = []
+
+    def fake_error(self, msg, *args, **kwargs):
+        calls.append((msg, args, kwargs))
+
+    monkeypatch.setattr(logging.Logger, "error", fake_error)
+
+    log_resource_usage_calls = []
+
+    def fake_log_resource_usage(self):
+        log_resource_usage_calls.append(True)
+
+    monkeypatch.setattr(CustomLogger, "log_resource_usage", fake_log_resource_usage)
+
+    logger.error_trace("msg", exc_info=True)
+
+    assert log_resource_usage_calls, "log_resource_usage should be called before delegating"
+    assert calls == [("msg", (), {"exc_info": True})]


### PR DESCRIPTION
## Summary
- update CustomLogger trace helper methods to only add exc_info when not provided while still logging resource usage
- add a unit test ensuring error_trace accepts an explicit exc_info argument and delegates to Logger.error

## Testing
- pytest testing/test_logger.py

------
https://chatgpt.com/codex/tasks/task_e_68cfb473cdd4832db7fb9b8ae3ffd40c