### PR TITLE
Enable threaded Flask dev server

### DIFF
--- a/app.py
+++ b/app.py
@@ -543,5 +543,7 @@ if __name__ == '__main__':
     app.run(
         host=FLASK_HOST,
         port=FLASK_PORT,
-        debug=DEBUG 
+        debug=DEBUG,
+        threaded=True,
+        use_reloader=DEBUG
     )


### PR DESCRIPTION
## Summary
- run the Flask development server with threading enabled and keep the reloader tied to DEBUG so local hot reloads continue to work

## Testing
- python -m compileall app.py
- Manual verification via patched dev server script to queue a download while polling /api/status

------
https://chatgpt.com/codex/tasks/task_e_68d06b2d5450832d865b579739fe4862