### PR TITLE
Add duplicate review UI and API

### DIFF
--- a/app.py
+++ b/app.py
@@ -288,6 +288,73 @@ def api_status() -> Union[Response, Tuple[Response, int]]:
         logger.error_trace(f"Status error: {e}")
         return jsonify({"error": str(e)}), 500
 
+
+@app.route('/api/duplicates', methods=['GET', 'POST'])
+@login_required
+def api_duplicates() -> Union[Response, Tuple[Response, int]]:
+    """Expose duplicate scan results and allow review state updates."""
+    if request.method == 'GET':
+        try:
+            data = backend.list_duplicates()
+            return jsonify(data)
+        except Exception as e:
+            logger.error_trace(f"Duplicate scan error: {e}")
+            return jsonify({"error": str(e)}), 500
+
+    payload = request.get_json(silent=True) or {}
+    action = payload.get('action')
+    group_id = payload.get('group_id')
+
+    if action not in {'mark_reviewed', 'clear_reviewed'} or not group_id:
+        return jsonify({"error": "Invalid action or group_id"}), 400
+
+    try:
+        backend.set_duplicate_reviewed(group_id, action == 'mark_reviewed')
+        return jsonify({
+            "status": "ok",
+            "group_id": group_id,
+            "reviewed": action == 'mark_reviewed',
+        })
+    except FileNotFoundError as e:
+        # If marking a group that no longer exists just clear the review state
+        logger.warning(f"Duplicate review target missing: {e}")
+        backend.set_duplicate_reviewed(group_id, False)
+        return jsonify({"status": "ok", "group_id": group_id, "reviewed": False})
+    except Exception as e:
+        logger.error_trace(f"Failed to update duplicate review state: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route('/api/duplicates/file', methods=['GET'])
+@login_required
+def api_duplicate_file() -> Union[Response, Tuple[Response, int]]:
+    """Send a file from the ingest directory associated with a duplicate group."""
+    relative_path = request.args.get('path', '')
+    inline = request.args.get('inline', '') == '1'
+
+    if not relative_path:
+        return jsonify({"error": "Missing path"}), 400
+
+    try:
+        file_path = backend.resolve_ingest_file(relative_path)
+    except FileNotFoundError:
+        return jsonify({"error": "File not found"}), 404
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        logger.error_trace(f"Duplicate file retrieval error: {e}")
+        return jsonify({"error": str(e)}), 500
+
+    try:
+        return send_file(
+            file_path,
+            as_attachment=not inline,
+            download_name=os.path.basename(file_path),
+        )
+    except Exception as e:
+        logger.error_trace(f"Failed to send duplicate file: {e}")
+        return jsonify({"error": str(e)}), 500
+
 @app.route('/api/localdownload', methods=['GET'])
 @login_required
 def api_local_download() -> Union[Response, Tuple[Response, int]]:

--- a/readme.md
+++ b/readme.md
@@ -288,11 +288,7 @@ While this tool can access various sources including those that might contain co
 
 ### Duplicate Downloads Warning
 
-Please note that the current version:
-
-- Does not check for existing files in the download directory
-- Does not verify if books already exist in your Calibre database
-- Exercise caution when requesting multiple books to avoid duplicates
+The downloader now scans the ingest directory (including any books you add manually) for duplicate candidates using both the sanitized filename stem and the file hash. Review the **Potential Duplicates** panel in the web UI to open or download the files, then mark each group as resolved once you have handled it. The warning banner will remain until the underlying files are removed or renamed, so you can still intentionally keep duplicate copies if desired.
 
 ## 💬 Support
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -195,6 +195,17 @@
             <div id="no-results" class="mt-4 text-sm opacity-80 hidden">No results found.</div>
         </section>
 
+        <!-- Duplicates -->
+        <section id="duplicates-section" class="mb-8">
+            <div class="flex items-center justify-between mb-3">
+                <h2 class="text-xl font-semibold">Potential Duplicates</h2>
+                <button id="refresh-duplicates-button" class="px-3 py-1 rounded border text-sm" style="border-color: var(--border-muted);">Refresh</button>
+            </div>
+            <div id="duplicates-loading" class="text-sm opacity-80 hidden">Scanning…</div>
+            <div id="duplicates-empty" class="text-sm opacity-80 hidden">No duplicates detected.</div>
+            <div id="duplicates-list" class="space-y-3"></div>
+        </section>
+
         <!-- Modal -->
         <div class="modal-overlay" id="modal-overlay" role="dialog" aria-modal="true">
             <div class="details-container" id="details-container"></div>


### PR DESCRIPTION
## Summary
- add backend helpers to detect duplicate files in the ingest directory and store review state
- expose `/api/duplicates` and file download endpoints so the UI can inspect and resolve duplicates
- surface the duplicate review panel in the web UI and document the updated workflow in the README

## Testing
- python -m py_compile backend.py app.py

------
https://chatgpt.com/codex/tasks/task_e_68d73c331dcc832d86336224a299882b